### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/typescript/browser-or-server/package.json
+++ b/packages/typescript/browser-or-server/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/browser-or-server"
+  },
   "main": "server.js",
   "browser": "browser.js",
   "keywords": [

--- a/packages/typescript/cached-expression-shared-utils/package.json
+++ b/packages/typescript/cached-expression-shared-utils/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/cached-expression-shared-utils"
+  },
   "keywords": [
     "util"
   ],

--- a/packages/typescript/clean-typescript-build/package.json
+++ b/packages/typescript/clean-typescript-build/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/clean-typescript-build"
+  },
   "main": "index.js",
   "bin": {
     "clean-typescript-build": "./bin/clean-typescript-build"

--- a/packages/typescript/convenient-typescript-utilities/package.json
+++ b/packages/typescript/convenient-typescript-utilities/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/convenient-typescript-utilities"
+  },
   "dependencies": {
     "tslib": "^1.10.0",
     "@types/node": "^13.1.6"

--- a/packages/typescript/extra-jest/package.json
+++ b/packages/typescript/extra-jest/package.json
@@ -9,6 +9,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/extra-jest"
+  },
   "keywords": [
     "jest"
   ],

--- a/packages/typescript/fs-tree-utils/package.json
+++ b/packages/typescript/fs-tree-utils/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/fs-tree-utils"
+  },
   "keywords": [
     "filesystem",
     "tree",

--- a/packages/typescript/monorepo-shared-assets/package.json
+++ b/packages/typescript/monorepo-shared-assets/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/monorepo-shared-assets"
+  },
   "dependencies": {
     "immutable": "^4.0.0-rc.12",
     "@tsfun/array": "^0.0.0",

--- a/packages/typescript/nested-workspace-helper/package.json
+++ b/packages/typescript/nested-workspace-helper/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/nested-workspace-helper"
+  },
   "main": "index.js",
   "bin": {
     "nested-workspace-helper": "bin/nested-wrkspc",

--- a/packages/typescript/parse-dependency-range/package.json
+++ b/packages/typescript/parse-dependency-range/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/parse-dependency-range"
+  },
   "keywords": [
     "dependency",
     "version",

--- a/packages/typescript/path-env/package.json
+++ b/packages/typescript/path-env/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/path-env"
+  },
   "keywords": [
     "PATH",
     "env",

--- a/packages/typescript/random-org-http/package.json
+++ b/packages/typescript/random-org-http/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/random-org-http"
+  },
   "keywords": [
     "random",
     "http",

--- a/packages/typescript/sh-or-cmd/package.json
+++ b/packages/typescript/sh-or-cmd/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/sh-or-cmd"
+  },
   "keywords": [
     "sh",
     "cmd",

--- a/packages/typescript/smart-publish/package.json
+++ b/packages/typescript/smart-publish/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/smart-publish"
+  },
   "keywords": [
     "publish",
     "prerelease",

--- a/packages/typescript/split-string-once/package.json
+++ b/packages/typescript/split-string-once/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/split-string-once"
+  },
   "keywords": [
     "split",
     "string",

--- a/packages/typescript/unique-temp-path/package.json
+++ b/packages/typescript/unique-temp-path/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/unique-temp-path"
+  },
   "keywords": [
     "temp",
     "unique"

--- a/packages/typescript/xor-compose/package.json
+++ b/packages/typescript/xor-compose/package.json
@@ -8,6 +8,11 @@
   "bugs": {
     "url": "https://github.com/ksxnodemodules/nodemonorepo/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ksxnodemodules/nodemonorepo.git",
+    "directory": "packages/typescript/xor-compose"
+  },
   "keywords": [
     "xor",
     "compose",


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• browser-or-server
• cached-expression-shared-utils
• clean-typescript-build
• convenient-typescript-utilities
• extra-jest
• fs-tree-utils
• monorepo-shared-assets
• nested-workspace-helper
• parse-dependency-range
• path-env
• random-org-http
• sh-or-cmd
• smart-publish
• split-string-once
• unique-temp-path
• xor-compose